### PR TITLE
Add guard to check presence of @config['encoding']

### DIFF
--- a/lib/overcommit/hook/pre_commit/rails_schema_up_to_date.rb
+++ b/lib/overcommit/hook/pre_commit/rails_schema_up_to_date.rb
@@ -35,6 +35,8 @@ module Overcommit::Hook::PreCommit
     private
 
     def encoding
+      return unless @config.key?('encoding')
+
       { encoding: @config['encoding'] }.compact
     end
 


### PR DESCRIPTION
Adds a guard to check for the presence of @config['encoding']. This fixes the failing Ruby 3 tests on https://github.com/sds/overcommit/pull/786

I didn't think it worth adding a test when no encoding key is present, as the other tests implicitly check the unhappy path.